### PR TITLE
fix: Add repository flag to make compatible with version command

### DIFF
--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-NEXT_VERSION=$(/action/get-next-version /github/workspace)
+NEXT_VERSION=$(/action/get-next-version -r /github/workspace)
 
 git tag "${NEXT_VERSION}"
 git push origin "${NEXT_VERSION}"

--- a/cli/root.go
+++ b/cli/root.go
@@ -10,17 +10,18 @@ import (
 	"github.com/thenativeweb/get-next-version/versioning"
 )
 
+var rootRepositoryFlag string
+
+func init() {
+	RootCommand.Flags().StringVarP(&rootRepositoryFlag, "repository", "r", ".", "path of the repository to operate on")
+}
+
 var RootCommand = &cobra.Command{
 	Use:   "get-next-version",
 	Short: "Get the next semantic version for your project",
 	Long:  "Get the next semantic version for your project based on your git history.",
-	Run: func(command *cobra.Command, args []string) {
-		if len(args) != 1 {
-			fmt.Println(command.UsageString())
-			return
-		}
-
-		repository, err := gogit.PlainOpen(args[0])
+	Run: func(command *cobra.Command, _ []string) {
+		repository, err := gogit.PlainOpen(rootRepositoryFlag)
 		if err != nil {
 			log.Fatal().Msg(err.Error())
 		}


### PR DESCRIPTION
I noticed after some more testing that using args for the root command conflicts with having subcommands (i.e.: version). From a parser perspective this makes total sense, because how should you decide if I want to target a directory called `version` or execute the `version` command. Therefore the repository path needs to be supplied using flags.
