### PR TITLE
chore: Add tests for handling versions with leading v.

### DIFF
--- a/git/commits_test.go
+++ b/git/commits_test.go
@@ -61,10 +61,23 @@ func TestGetConventionalCommitTypesSinceLatestRelease(t *testing.T) {
 		},
 		{
 			commitHistory: []commit{
-				{message: "chore: irelevant", tag: "0.0.1"},
+				{message: "chore: irrelevant", tag: "0.0.1"},
 				{message: "feat: because it is", tag: ""},
 				{message: "feat(scope)!: before the last tag", tag: "0.0.2"},
 				{message: "chore: Do something", tag: "1.0.0"},
+				{message: "chore: Do something else", tag: ""},
+			},
+			doExpectError:                   false,
+			expectedLastVersion:             semver.MustParse("1.0.0"),
+			expectedConventionalCommitTypes: []conventionalcommits.Type{conventionalcommits.Chore},
+			annotateTags:                    false,
+		},
+		{
+			commitHistory: []commit{
+				{message: "chore: irrelevant", tag: "v0.0.1"},
+				{message: "feat: because it is", tag: ""},
+				{message: "feat(scope)!: before the last tag", tag: "0.0.2"},
+				{message: "chore: Do something", tag: "v1.0.0"},
 				{message: "chore: Do something else", tag: ""},
 			},
 			doExpectError:                   false,
@@ -137,8 +150,13 @@ func TestGetConventionalCommitTypesSinceLatestRelease(t *testing.T) {
 		}
 
 		assert.NoError(t, err)
-		assert.Equal(t, test.expectedLastVersion, actual.LatestReleaseVersion)
+
+		// We need to compare using semver's own Equal function, because under
+		// the hood it makes a difference between versions with a leading v and
+		// versions without a leading v. However, when printing them, they are
+		// actually both shown without the v.
+		assert.True(t, test.expectedLastVersion.Equal(actual.LatestReleaseVersion))
+		assert.Equal(t, test.expectedLastVersion.String(), actual.LatestReleaseVersion.String())
 		assert.ElementsMatch(t, test.expectedConventionalCommitTypes, actual.ConventionalCommitTypes)
 	}
-
 }

--- a/git/commits_test.go
+++ b/git/commits_test.go
@@ -151,12 +151,11 @@ func TestGetConventionalCommitTypesSinceLatestRelease(t *testing.T) {
 
 		assert.NoError(t, err)
 
-		// We need to compare using semver's own Equal function, because under
-		// the hood it makes a difference between versions with a leading v and
-		// versions without a leading v. However, when printing them, they are
-		// actually both shown without the v.
+		// The test in the next line is not optimal. We rely on the Equal
+		// function of the SemVer module here, which considers v1.0.0 and
+		// 1.0.0 to be the same. In contrast to this, assert.Equal fails
+		// when comparing these two versions, due to the leading v.
 		assert.True(t, test.expectedLastVersion.Equal(actual.LatestReleaseVersion))
-		assert.Equal(t, test.expectedLastVersion.String(), actual.LatestReleaseVersion.String())
 		assert.ElementsMatch(t, test.expectedConventionalCommitTypes, actual.ConventionalCommitTypes)
 	}
 }

--- a/git/tags_test.go
+++ b/git/tags_test.go
@@ -22,6 +22,11 @@ func TestGetAllSemVerTags(t *testing.T) {
 			expectedTagNames: []string{"1.0.0"},
 		},
 		{
+			tagsPerBranch:    map[string][][]string{"main": {{"v1.0.0"}}},
+			doesExpectError:  false,
+			expectedTagNames: []string{"1.0.0"},
+		},
+		{
 			tagsPerBranch:    map[string][][]string{"main": {{"1.0.0"}, {"2.0.0"}}},
 			doesExpectError:  false,
 			expectedTagNames: []string{"1.0.0", "2.0.0"},
@@ -33,6 +38,11 @@ func TestGetAllSemVerTags(t *testing.T) {
 		},
 		{
 			tagsPerBranch:    map[string][][]string{"main": {{"1.0.0"}, {"2.0.0"}, {"feature-tag"}}},
+			doesExpectError:  false,
+			expectedTagNames: []string{"1.0.0", "2.0.0"},
+		},
+		{
+			tagsPerBranch:    map[string][][]string{"main": {{"1.0.0"}, {"v2.0.0"}, {"vsomething-else"}}},
 			doesExpectError:  false,
 			expectedTagNames: []string{"1.0.0", "2.0.0"},
 		},


### PR DESCRIPTION
Related to #37 