### PR TITLE
fix: Set github admin token when cloning repository.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'main'
 
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+
 jobs:
   qa:
     name: Release
@@ -14,7 +17,8 @@ jobs:
     - name: Clone repository
       uses: actions/checkout@v3
       with:
-        fetch-depth: 0
+        fetch-depth: '0'
+        token: ${{ env.GH_TOKEN }}
     - name: Use Go
       uses: actions/setup-go@v3
       with:


### PR DESCRIPTION
This is necessary because the `action/checkout` Action persists the credentials it is given and lets later steps re-use them. The `EndBug/add-and-commit` action needs this to be able to push the release commit.