### PR TITLE
chore: Lint PR title.

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,23 @@
+name: Lint PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  lint-pr-title:
+    name: Lint PR title
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            chore
+            feat
+            fix


### PR DESCRIPTION
Hey @mr-roadl 👋 

This PR introduces a new workflow which lints the PR title to ensure that we always have a prefix according to conventional commit messages (i.e., either `chore`, `feat` or `fix`).

Can you please review this?