### PR TITLE
feat: add option for version prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Optionally, you may hand over the `--repository` (or short `-r`) flag to specify
 $ get-next-version --repository <PATH>
 ```
 
-If you need to prefix the version, you can use the `--version-prefix` (or short `-p`) flag.
+If you need to prefix the version, you can use the `--prefix` (or short `-p`) flag.
 
 By default, output will be shown in a human-readable format. If you want to show the output in a machine-readable format, you can use the `--format` (or short `-f`) flag:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Optionally, you may hand over the `--repository` (or short `-r`) flag to specify
 $ get-next-version --repository <PATH>
 ```
 
+If you need to prefix the version, you can use the `--version-prefix` (or short `-p`) flag.
+
 By default, output will be shown in a human-readable format. If you want to show the output in a machine-readable format, you can use the `--format` (or short `-f`) flag:
 
 ```shell

--- a/cli/root.go
+++ b/cli/root.go
@@ -15,12 +15,12 @@ import (
 
 var rootRepositoryFlag string
 var rootFormatFlag string
-var rootVersionPrefixFlag string
+var rootPrefixFlag string
 
 func init() {
 	RootCommand.Flags().StringVarP(&rootRepositoryFlag, "repository", "r", ".", "sets the path to the repository")
 	RootCommand.Flags().StringVarP(&rootFormatFlag, "format", "f", "version", "sets the output format")
-	RootCommand.Flags().StringVarP(&rootVersionPrefixFlag, "version-prefix", "p", "", "sets the version prefix")
+	RootCommand.Flags().StringVarP(&rootPrefixFlag, "prefix", "p", "", "sets the version prefix")
 }
 
 var RootCommand = &cobra.Command{
@@ -52,7 +52,7 @@ var RootCommand = &cobra.Command{
 			nextVersion, hasNextVersion = versioning.CalculateNextVersion(result.LatestReleaseVersion, result.ConventionalCommitTypes)
 		}
 
-		lines := cliutil.Format(nextVersion, hasNextVersion, rootFormatFlag, rootVersionPrefixFlag)
+		lines := cliutil.Format(nextVersion, hasNextVersion, rootFormatFlag, rootPrefixFlag)
 		for _, line := range lines {
 			fmt.Println(line)
 		}

--- a/cli/root.go
+++ b/cli/root.go
@@ -15,10 +15,12 @@ import (
 
 var rootRepositoryFlag string
 var rootFormatFlag string
+var rootVersionPrefixFlag string
 
 func init() {
 	RootCommand.Flags().StringVarP(&rootRepositoryFlag, "repository", "r", ".", "sets the path to the repository")
 	RootCommand.Flags().StringVarP(&rootFormatFlag, "format", "f", "version", "sets the output format")
+	RootCommand.Flags().StringVarP(&rootVersionPrefixFlag, "version-prefix", "p", "", "sets the version prefix")
 }
 
 var RootCommand = &cobra.Command{
@@ -50,7 +52,7 @@ var RootCommand = &cobra.Command{
 			nextVersion, hasNextVersion = versioning.CalculateNextVersion(result.LatestReleaseVersion, result.ConventionalCommitTypes)
 		}
 
-		lines := cliutil.Format(nextVersion, hasNextVersion, rootFormatFlag)
+		lines := cliutil.Format(nextVersion, hasNextVersion, rootFormatFlag, rootVersionPrefixFlag)
 		for _, line := range lines {
 			fmt.Println(line)
 		}

--- a/cliutil/format.go
+++ b/cliutil/format.go
@@ -2,24 +2,28 @@ package cliutil
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver"
 )
 
-func Format(nextVersion semver.Version, hasNextVersion bool, format string) []string {
+func Format(nextVersion semver.Version, hasNextVersion bool, format string, prefix ...string) []string {
+	prefixString := strings.Join(prefix, "")
+	versionString := prefixString + nextVersion.String()
+
 	switch format {
 	case "github-action":
 		return []string{
-			fmt.Sprintf("::set-output name=version::%s", nextVersion.String()),
+			fmt.Sprintf("::set-output name=version::%s", versionString),
 			fmt.Sprintf("::set-output name=hasNextVersion::%v", hasNextVersion),
 		}
 	case "json":
 		return []string{
-			fmt.Sprintf(`{"version": "%s", "hasNextVersion": %v}`, nextVersion.String(), hasNextVersion),
+			fmt.Sprintf(`{"version": "%s", "hasNextVersion": %v}`, versionString, hasNextVersion),
 		}
 	case "version":
 		return []string{
-			nextVersion.String(),
+			versionString,
 		}
 	default:
 		panic("invalid format")

--- a/cliutil/format.go
+++ b/cliutil/format.go
@@ -2,14 +2,11 @@ package cliutil
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/Masterminds/semver"
 )
 
-func Format(nextVersion semver.Version, hasNextVersion bool, format string, prefix ...string) []string {
-	prefixString := strings.Join(prefix, "")
-	versionString := prefixString + nextVersion.String()
+func Format(nextVersion semver.Version, hasNextVersion bool, format string, prefix string) []string {
+	versionString := prefix + nextVersion.String()
 
 	switch format {
 	case "github-action":

--- a/cliutil/format_test.go
+++ b/cliutil/format_test.go
@@ -12,39 +12,55 @@ func TestFormat(t *testing.T) {
 	version, err := semver.NewVersion("1.2.3")
 	assert.NoError(t, err)
 
-	output := cliutil.Format(*version, true, "github-action")
+	output := cliutil.Format(*version, true, "github-action", "")
 	assert.Equal(t, []string{
 		"::set-output name=version::1.2.3",
 		"::set-output name=hasNextVersion::true",
 	}, output)
 
-	output = cliutil.Format(*version, false, "github-action")
+	output = cliutil.Format(*version, false, "github-action", "")
 	assert.Equal(t, []string{
 		"::set-output name=version::1.2.3",
 		"::set-output name=hasNextVersion::false",
 	}, output)
 
-	output = cliutil.Format(*version, true, "json")
+	output = cliutil.Format(*version, false, "github-action", "v")
+	assert.Equal(t, []string{
+		"::set-output name=version::v1.2.3",
+		"::set-output name=hasNextVersion::false",
+	}, output)
+
+	output = cliutil.Format(*version, true, "json", "")
 	assert.Equal(t, []string{
 		`{"version": "1.2.3", "hasNextVersion": true}`,
 	}, output)
 
-	output = cliutil.Format(*version, false, "json")
+	output = cliutil.Format(*version, false, "json", "")
 	assert.Equal(t, []string{
 		`{"version": "1.2.3", "hasNextVersion": false}`,
 	}, output)
 
-	output = cliutil.Format(*version, true, "version")
+	output = cliutil.Format(*version, false, "json", "v")
+	assert.Equal(t, []string{
+		`{"version": "v1.2.3", "hasNextVersion": false}`,
+	}, output)
+
+	output = cliutil.Format(*version, true, "version", "")
 	assert.Equal(t, []string{
 		"1.2.3",
 	}, output)
 
-	output = cliutil.Format(*version, false, "version")
+	output = cliutil.Format(*version, false, "version", "")
 	assert.Equal(t, []string{
 		"1.2.3",
+	}, output)
+
+	output = cliutil.Format(*version, false, "version", "v")
+	assert.Equal(t, []string{
+		"v1.2.3",
 	}, output)
 
 	assert.Panics(t, func() {
-		cliutil.Format(*version, true, "non-existent-format")
+		cliutil.Format(*version, true, "non-existent-format", "")
 	})
 }


### PR DESCRIPTION
Hi,

I am a follower of your Youtube channel and user of this tool. I am seeing myself needing the option for `v` prefixes while releasing golang library packages.

Unfortunately, my sed/awk workflow does not look very pretty.

Kind regards
Florian

