### PR TITLE
chore: use alpine as Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,8 @@ FROM golang:1.18.3-alpine as build
 RUN mkdir /app
 WORKDIR /app
 
-RUN apk update
-RUN apk add --no-cache build-base
-RUN apk add --no-cache make
+RUN apk update && \
+    apk add --no-cache build-base make
 
 ADD . .
 RUN make build
@@ -14,8 +13,8 @@ RUN make build
 
 FROM alpine:3.18.4
 
-RUN apk update 
-RUN apk add --no-cache git
+RUN apk update && \
+    apk add --no-cache git
 
 RUN mkdir /action
 WORKDIR /action

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,21 @@
-FROM golang:1.18.3-bullseye as build
+FROM golang:1.18.3-alpine as build
 
 RUN mkdir /app
 WORKDIR /app
+
+RUN apk update
+RUN apk add --no-cache build-base
+RUN apk add --no-cache make
 
 ADD . .
 RUN make build
 
 
 
-FROM debian:bullseye
+FROM alpine:3.18.4
 
-RUN apt update
-RUN apt install -y git
+RUN apk update 
+RUN apk add --no-cache git
 
 RUN mkdir /action
 WORKDIR /action

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /app
 WORKDIR /app
 
 RUN apk update && \
-    apk add --no-cache build-base make
+    apk add --no-cache build-base git make
 
 ADD . .
 RUN make build


### PR DESCRIPTION
This PR is a suggestion to reduce the size of the Docker image from ~250MB to ~30MB.

Are there currently any reasons for a Debian image? If that is the case, unfortunately I am not aware of them. If everything is fine, this could save some time for CI pipelines.

Please let me know if I should add some comments, the Alpine image requires `build-base` for the gcc compiler and `make` to support the Makefile.