### PR TITLE
fix: fixed merge commits detection

### DIFF
--- a/git/commits.go
+++ b/git/commits.go
@@ -29,7 +29,10 @@ func GetConventionalCommitTypesSinceLastRelease(repository *git.Repository) (Con
 		}
 		return ConventionalCommmitTypesResult{}, err
 	}
-	commitIterator, err := repository.Log(&git.LogOptions{From: head.Hash()})
+	commitIterator, err := repository.Log(&git.LogOptions{
+		From:  head.Hash(),
+		Order: git.LogOrderCommitterTime,
+	})
 	if err != nil {
 		return ConventionalCommmitTypesResult{}, err
 	}


### PR DESCRIPTION
When searching for commits, `go-git` uses depth-first search by default. In cases where commits are brought in via a merge commit, the commits other than the merge commit itself will be missed, as the DFS will go down the commits directly from HEAD, and will exit upon finding the previous tag, before then searching other paths. This is fixed by using the sort orders `LogOrderCommitterTime` or `LogOrderBSF`. Here `LogOrderCommitterTime` was used as the `go-git` documentation says it has the highest compatibility with the `git log` CLI command.