### PR TITLE
fix: bump Go to 1.26 to repair the release build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.1-alpine3.21 as build
+FROM golang:1.26-alpine3.22 AS build
 
 RUN mkdir /app
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thenativeweb/get-next-version
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
## Problem

The **Release** workflow on `main` has been failing on every push (e.g. runs [#194](https://github.com/thenativeweb/get-next-version/actions/runs/27804619457) and #193). The `Get next version` step fails while building the action's Docker image:

```
#17 0.130 go: go.mod requires go >= 1.25.0 (running go 1.24.1; GOTOOLCHAIN=local)
#17 0.131 make: *** [Makefile:18: analyze] Error 1
```

### Root cause

`go.mod` was raised to `go 1.25.0` (via Dependabot #191 on 2026-05-11), but the `Dockerfile` still built on `golang:1.24.1-alpine3.21`. The official `golang` image pins `GOTOOLCHAIN=local`, so Go cannot download a newer toolchain inside the container and bails out as soon as `go vet` runs. The checkout bump in #194 only re-triggered the workflow — it was not the cause.

## Fix

Align everything on **Go 1.26** (latest stable; 1.27 is only an RC):

- `go.mod`: `go 1.25.0` → `go 1.26.0`
- `Dockerfile` build stage: `golang:1.24.1-alpine3.21` → `golang:1.26-alpine3.22` (minor pin, so future patch bumps are picked up automatically; `alpine3.21` no longer exists for the 1.26 line)
- Fixes the `FromAsCasing` warning (`as` → `AS`)

The `qa.yml` and `release.yml` workflows read the Go version via `go-version-file: ./go.mod`, so they track this change automatically — no workflow edits needed.

## Verification

Built the image locally with the exact `docker build` the release step runs:

- ✅ `make build` (`go vet` + full test suite) passes on Go 1.26
- ✅ image builds successfully, no more warnings
- ✅ the resulting binary runs in the final `alpine:3.21.3` runtime stage (musl-compatible across the Alpine version gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)