### PR TITLE
chore: Group Dependabot updates and align commit prefixes.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,45 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  cooldown:
-    default-days: 7
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  assignees:
-  - thenativeweb/internal_dev
-  labels:
-  - Dependencies
-  allow:
-  - dependency-type: direct
-  commit-message:
-    prefix: chore
-    prefix-development: chore
+  - package-ecosystem: gomod
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    assignees:
+      - goloroden
+    labels:
+      - Dependencies
+    allow:
+      - dependency-type: direct
+    commit-message:
+      prefix: fix
+    groups:
+      gomod:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
-- package-ecosystem: "github-actions"
-  directory: "/"
-  cooldown:
-    default-days: 7
-  schedule:
-    interval: "weekly"
-  open-pull-requests-limit: 10
-  assignees:
-  - thenativeweb/internal_dev
-  labels:
-  - Dependencies
-  commit-message:
-    prefix: chore
+  - package-ecosystem: github-actions
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    assignees:
+      - goloroden
+    labels:
+      - Dependencies
+    commit-message:
+      prefix: chore
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## What

Overhaul the Dependabot configuration to group updates and make commit prefixes release-aware, consistent with the org-wide convention rolled out across the thenativeweb repositories.

### Grouping

- Minor and patch updates are bundled into one pull request per ecosystem.
- Major updates keep coming in individually, so breaking changes stay isolated and reviewable.
- Where an ecosystem distinguishes production from development dependencies (npm, pip, composer, mix), they are split into separate `*-production` / `*-development` groups.

### Commit prefixes (release behavior)

Prefixes now reflect what actually ships in the product: ecosystems whose updates change the released artifact use `fix` (triggering a patch release via get-next-version), while CI (`github-actions`), test, and documentation tooling uses `chore` (release-neutral). Production dependencies use `fix`, development/test dependencies use `chore`.

### Assignee

Replaces the team assignee `thenativeweb/internal_dev` (which GitHub rejects, since assignees must be individual users, not teams) with `goloroden`. Team review already runs through CODEOWNERS plus branch protection, so nothing is lost.

## Why

Reduce the volume of routine dependency pull requests without hiding breaking changes, and align the release-triggering behavior of dependency updates with whether they actually affect the shipped product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEb1kvMyuGfpybysH3N7Ln
