### PR TITLE
chore: Raise Go to 1.27.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine3.22 AS build
+FROM golang:1.27.1-alpine3.23 AS build
 
 RUN mkdir /app
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thenativeweb/get-next-version
 
-go 1.26.0
+go 1.27.1
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
## Why

Go 1.27.1 across the organization. The occasion was `staticcheck@latest`, which began requiring Go >= 1.26 and turned three repositories red at once — this repository was not affected, because it analyzes with `go vet` only.

It comes along so that the whole organization builds on one Go version, and 1.27.1 rather than 1.26 because 1.26 is exactly staticcheck's current floor elsewhere.

## What changed

Only the `go` directive, and the `golang` image where a `Dockerfile` uses one. **No staticcheck was introduced here** — this repository does not use it, and a sweep is no reason to add a tool nobody asked for.

## Verified

- `go vet ./...` → clean
- `go build ./...` → clean
- `go test ./...` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2SKRAbkaRS7VvzZRaiRGi
